### PR TITLE
refactor: move @Id de document para email em UserLogin

### DIFF
--- a/src/main/java/api/security/auth/app/model/UserLogin.java
+++ b/src/main/java/api/security/auth/app/model/UserLogin.java
@@ -24,14 +24,18 @@ import java.util.List;
 @NoArgsConstructor
 public class UserLogin implements UserDetails {
 
-    @Id
     private String document;
 
     private String name;
+    
+    @Id
+    @Column(unique = true)
     private String email;
+    
     private String phoneNumber;
     private String tipo;
     private String password;
+    
 
     @Column(updatable = false)
     private LocalDateTime registerDate = LocalDateTime.now();


### PR DESCRIPTION
- Removida a anotação @Id do campo "document"
- Passado o @Id apenas para o campo "email" (PK única)
- Garantida a remoção de chaves compostas acidentais